### PR TITLE
OS10のショートカット共有について

### DIFF
--- a/SharingShortcuts/Application/build.gradle
+++ b/SharingShortcuts/Application/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.sharetarget:sharetarget:1.0.0-beta01'
+    // implementation 'androidx.sharetarget:sharetarget:1.0.0-beta01'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
 
 

--- a/SharingShortcuts/Application/src/main/java/com/example/android/sharingshortcuts/MainActivity.java
+++ b/SharingShortcuts/Application/src/main/java/com/example/android/sharingshortcuts/MainActivity.java
@@ -82,8 +82,7 @@ public class MainActivity extends Activity {
         Intent sharingIntent = new Intent(android.content.Intent.ACTION_SEND);
         sharingIntent.setType("text/plain");
         sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, mEditBody.getText().toString());
-        // (Optional) If you want a preview title, set it with Intent.EXTRA_TITLE
-        // Intent.EXTRA_TITLE: シェアするリンクテキストのプレビュー機能が OS: 10から追加された。
+        // (Optional) If you want a preview title, set it with Intent.EXTRA_TITLE.
         sharingIntent.putExtra(Intent.EXTRA_TITLE, getString(R.string.send_intent_title));
 
         // (Optional) if you want a preview thumbnail, create a content URI and add it

--- a/SharingShortcuts/Application/src/main/java/com/example/android/sharingshortcuts/MainActivity.java
+++ b/SharingShortcuts/Application/src/main/java/com/example/android/sharingshortcuts/MainActivity.java
@@ -83,6 +83,7 @@ public class MainActivity extends Activity {
         sharingIntent.setType("text/plain");
         sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, mEditBody.getText().toString());
         // (Optional) If you want a preview title, set it with Intent.EXTRA_TITLE
+        // Intent.EXTRA_TITLE: シェアするリンクテキストのプレビュー機能が OS: 10から追加された。
         sharingIntent.putExtra(Intent.EXTRA_TITLE, getString(R.string.send_intent_title));
 
         // (Optional) if you want a preview thumbnail, create a content URI and add it

--- a/SharingShortcuts/Application/src/main/java/com/example/android/sharingshortcuts/SharingShortcutsManager.java
+++ b/SharingShortcuts/Application/src/main/java/com/example/android/sharingshortcuts/SharingShortcutsManager.java
@@ -18,6 +18,7 @@ package com.example.android.sharingshortcuts;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.Person;
@@ -78,18 +79,24 @@ public class SharingShortcutsManager {
             Contact contact = Contact.byId(id);
 
             // Item that will be sent if the shortcut is opened as a static launcher shortcut
-            Intent staticLauncherShortcutIntent = new Intent(Intent.ACTION_DEFAULT);
+            Intent staticLauncherShortcutIntent = new Intent(Intent.ACTION_SENDTO);
+            staticLauncherShortcutIntent.setData(Uri.parse("mailto:aaa@gmail.com"));
+            staticLauncherShortcutIntent.putExtra(Intent.EXTRA_TITLE, "タイトル");
+            staticLauncherShortcutIntent.putExtra(Intent.EXTRA_TEXT, "メッセージ");
 
             // Creates a new Sharing Shortcut and adds it to the list
             // The id passed in the constructor will become EXTRA_SHORTCUT_ID in the received Intent
             shortcuts.add(new ShortcutInfoCompat.Builder(context, Integer.toString(id))
+                    // 個人を対象とするショートカットを公開する場合はLongLabelにフルネームを設定する
+                    .setLongLabel(contact.getName() + " Full Name")
+                    // ShortLabelにニックネームなどの短縮名を入れる
                     .setShortLabel(contact.getName())
                     // Icon that will be displayed in the share target
                     .setIcon(IconCompat.createWithResource(context, contact.getIcon()))
                     .setIntent(staticLauncherShortcutIntent)
                     // Make this sharing shortcut cached by the system
                     // Even if it is unpublished, it can still appear on the sharesheet
-                    .setLongLived()
+                    .setLongLived() // ショートカットの永続性を高める.
                     .setCategories(contactCategories)
                     // Person objects are used to give better suggestions
                     .setPerson(new Person.Builder()
@@ -97,7 +104,7 @@ public class SharingShortcutsManager {
                             .build())
                     .build());
         }
-
+        // Sharing Shortcuts APIを実行している箇所.
         ShortcutManagerCompat.addDynamicShortcuts(context, shortcuts);
     }
 


### PR DESCRIPTION
[ショートカット共有](https://developer.android.com/about/versions/10/highlights#sharing_shortcuts)についての調査メモ。
ショートカット共有とは、共有をすばやく簡単にできるようにするための機能で、
- コンテンツを共有する別のアプリを起動できる
- アプリ内の特定のアクティビティを起動できる

## reference
https://developer.android.com/about/versions/10/highlights#sharing_shortcuts
https://developer.android.com/training/sharing/receive#sharing-shortcuts-api
https://developer.android.com/training/sharing/receive#get-best-ranking
[サンプルアプリ](https://github.com/android/storage-samples/tree/main/SharingShortcuts)