### PR TITLE
ファイルピッカーを起動してファイル選択する実装について

### DIFF
--- a/ActionOpenDocument/app/src/main/java/com/example/android/actionopendocument/MainActivity.kt
+++ b/ActionOpenDocument/app/src/main/java/com/example/android/actionopendocument/MainActivity.kt
@@ -89,6 +89,7 @@ class MainActivity : AppCompatActivity() {
         if (requestCode == OPEN_DOCUMENT_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             resultData?.data?.also { documentUri ->
 
+                // デバイスの再起動後もファイルへのアクセス権を維持したい場合は takePersistableUriPermission  を呼び出す必要がある.
                 /**
                  * Upon getting a document uri returned, we can use
                  * [ContentResolver.takePersistableUriPermission] in order to persist the
@@ -114,6 +115,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    // ACTION_OPEN_DOCUMENT インテントを使ってファイルピッカーを起動する
     private fun openDocumentPicker() {
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
             /**

--- a/ActionOpenDocument/build.gradle
+++ b/ActionOpenDocument/build.gradle
@@ -16,9 +16,9 @@
 
 buildscript {
     ext {
-        compileSdkVersion = 28
+        compileSdkVersion = 30
         minSdkVersion = 24
-        targetSdkVersion = 28
+        targetSdkVersion = 30
 
         espressoVersion = '3.0.1'
         junitVersion = '4.12'


### PR DESCRIPTION
- ファイルピッカーを起動するために必要なintent actionがある
ファイル選択するには[ACTION_OPEN_DOCUMENT](https://developer.android.com/reference/android/content/Intent?hl=ja#ACTION_OPEN_DOCUMENT) インテントが必要
ref: https://youtu.be/UnJ3amzJM94?t=1868

# キャプチャ

ファイルピッカーは以下のようなやつ。
| ピクセル5 OS:10 |
|----| 
| <img src="https://user-images.githubusercontent.com/16476224/115047910-f5aeca00-9f13-11eb-8fb3-4e8aa5fea542.gif" width=320 /> |