### PR TITLE
ファイルピッカーを起動してディレクトリ選択する実装について

### DIFF
--- a/ActionOpenDocumentTree/app/build.gradle
+++ b/ActionOpenDocumentTree/app/build.gradle
@@ -21,11 +21,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.example.android.ktfiles"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/DirectoryFragment.kt
+++ b/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/DirectoryFragment.kt
@@ -100,6 +100,7 @@ class DirectoryFragment : Fragment() {
 
     private fun openDocument(document: CachingDocumentFile) {
         try {
+            // アプリ内で読み込んだdocumentを表示できる外部アプリを起動する.
             val openIntent = Intent(Intent.ACTION_VIEW).apply {
                 flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
                 data = document.uri

--- a/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/MainActivity.kt
+++ b/ActionOpenDocumentTree/app/src/main/java/com/example/android/ktfiles/MainActivity.kt
@@ -22,6 +22,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.commit
 import androidx.fragment.app.transaction
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import kotlinx.android.synthetic.main.activity_main.toolbar
@@ -63,6 +64,7 @@ class MainActivity : AppCompatActivity() {
         if (requestCode == OPEN_DIRECTORY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             val directoryUri = data?.data ?: return
 
+            // デバイスの再起動後もファイルへのアクセス権を維持したい場合は takePersistableUriPermission  を呼び出す必要がある.
             contentResolver.takePersistableUriPermission(
                 directoryUri,
                 Intent.FLAG_GRANT_READ_URI_PERMISSION
@@ -72,7 +74,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun showDirectoryContents(directoryUri: Uri) {
-        supportFragmentManager.transaction {
+        supportFragmentManager.commit {
             val directoryTag = directoryUri.toString()
             val directoryFragment = DirectoryFragment.newInstance(directoryUri)
             replace(R.id.fragment_container, directoryFragment, directoryTag)
@@ -80,6 +82,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    // ディレクトリ選択するには、 ACTION_OPEN_DOCUMENT_TREE インテントを使ってファイルピッカーを起動する
     private fun openDirectory() {
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
         startActivityForResult(intent, OPEN_DIRECTORY_REQUEST_CODE)


### PR DESCRIPTION
- ファイルピッカーを起動するために必要なintent actionがある
フォルダ選択するには[ACTION_OPEN_DOCUMENT_TREE](https://developer.android.com/reference/android/content/Intent?hl=ja#ACTION_OPEN_DOCUMENT_TREE) インテントが必要
ref: https://youtu.be/UnJ3amzJM94?t=1868

Android 10からフォルダへのアクセス許可ダイアログが表示されるようになった。
<img width="366" alt="スクリーンショット 2021-04-28 22 47 36" src="https://user-images.githubusercontent.com/16476224/116414967-eca6ec80-a873-11eb-9022-0dc670f034d2.png">


| Pixel 4 OS9 | Pixel 4 OS10 |
|:---|:---:|
|<img src="https://user-images.githubusercontent.com/16476224/116413362-81a8e600-a872-11eb-9769-1eb27a3f2a84.gif" width=320 /> |<img src="https://user-images.githubusercontent.com/16476224/116414626-933ebd80-a873-11eb-9e6a-8d7fea260651.gif" width=320 /> |