### PR TITLE
OS10: 外部ストレージ内の全てのファイルのアクセス権を取得する方法(Read Only)

### DIFF
--- a/FileManager/app/src/main/AndroidManifest.xml
+++ b/FileManager/app/src/main/AndroidManifest.xml
@@ -2,11 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.android.samples.filemanager">
 
-    <!-- OS:11 からは、External storageへのアクセスにMANAGE_EXTERNAL_STORAGEパーミッションが必要 -->
+    <!-- OS:11 からは、共有ストレージへ内の全てのファイルへのアクセスにMANAGE_EXTERNAL_STORAGEパーミッションが必要 -->
     <uses-permission
         android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         android:minSdkVersion="30" />
-    <!-- OS:10 までは、External storageへのアクセスにREAD_EXTERNAL_STORAGEパーミッションが必要 -->
+    <!-- OS:10 までは、共有ストレージへ内の全てのファイルへのアクセスにREAD_EXTERNAL_STORAGEパーミッションが必要 -->
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="29" />

--- a/FileManager/app/src/main/AndroidManifest.xml
+++ b/FileManager/app/src/main/AndroidManifest.xml
@@ -2,9 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.android.samples.filemanager">
 
+    <!-- OS:11 からは、External storageへのアクセスにMANAGE_EXTERNAL_STORAGEパーミッションが必要 -->
     <uses-permission
         android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         android:minSdkVersion="30" />
+    <!-- OS:10 までは、External storageへのアクセスにREAD_EXTERNAL_STORAGEパーミッションが必要 -->
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="29" />
@@ -25,6 +27,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- ファイル共有するのに必要なproviderの宣言. -->
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"

--- a/FileManager/app/src/main/java/com/android/samples/filemanager/FileExplorerActivity.kt
+++ b/FileManager/app/src/main/java/com/android/samples/filemanager/FileExplorerActivity.kt
@@ -53,7 +53,7 @@ class FileExplorerActivity : AppCompatActivity() {
         hasPermission = checkStoragePermission(this)
         if (hasPermission) {
             if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-                if (!Environment.isExternalStorageLegacy()) {
+                if (!Environment.isExternalStorageLegacy()) { // android:requestLegacyExternalStorageフラグを確認するコード.
                     binding.rationaleView.visibility = View.GONE
                     binding.legacyStorageView.visibility = View.VISIBLE
                     return

--- a/FileManager/app/src/main/java/com/android/samples/filemanager/PermissionUtils.kt
+++ b/FileManager/app/src/main/java/com/android/samples/filemanager/PermissionUtils.kt
@@ -49,6 +49,7 @@ fun openPermissionSettings(activity: AppCompatActivity) {
         requestStoragePermissionApi30(activity)
     }
     else {
+        // OS: 10までは従来の方法で設定アプリのパーミッション許可画面を開く
         activity.startActivity(
             Intent(
                 Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
@@ -93,6 +94,7 @@ fun requestStoragePermission(activity: AppCompatActivity) {
     }
 }
 
+// OS 11からexternal storageのアクセス許可されてるかのチェックには、[AppOpsManager]を使う.
 @RequiresApi(30)
 fun checkStoragePermissionApi30(activity: AppCompatActivity): Boolean {
     val appOps = activity.getSystemService(AppOpsManager::class.java)
@@ -105,6 +107,7 @@ fun checkStoragePermissionApi30(activity: AppCompatActivity): Boolean {
     return mode == AppOpsManager.MODE_ALLOWED
 }
 
+// OS 11からACTION_MANAGE_ALL_FILES_ACCESS_PERMISSIONのintent actionを使ってexternal storageへのアクセス許可設定画面を開く.
 @RequiresApi(30)
 fun requestStoragePermissionApi30(activity: AppCompatActivity) {
     val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
@@ -112,6 +115,7 @@ fun requestStoragePermissionApi30(activity: AppCompatActivity) {
     activity.startActivityForResult(intent, MANAGE_EXTERNAL_STORAGE_PERMISSION_REQUEST)
 }
 
+// OS 10までは従来の方法で、external storageのアクセス許可されてるかのチェックを行う.
 @RequiresApi(19)
 fun checkStoragePermissionApi19(activity: AppCompatActivity): Boolean {
     val status =
@@ -120,6 +124,7 @@ fun checkStoragePermissionApi19(activity: AppCompatActivity): Boolean {
     return status == PackageManager.PERMISSION_GRANTED
 }
 
+// OS 10までは従来の方法で、external storageへのアクセス許可設定ダイアログを開く.
 @RequiresApi(19)
 fun requestStoragePermissionApi19(activity: AppCompatActivity) {
     val permissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)


### PR DESCRIPTION
https://support.google.com/googleplay/android-developer/answer/9956427?hl=ja
Android 11（API レベル 30）をターゲットとし、すべてのファイルへのアクセスをリクエストするアプリ(`MANAGE_EXTERNAL_STORAGE`を使うアプリ)については、2021 年初頭まで Google Play へのアップロードができなくなった。なので、`MediaStore` APIを使うなど代替手段を取る必要がある。

# Capture

<img src="https://user-images.githubusercontent.com/16476224/115138975-56e8b180-a06a-11eb-944a-6cd2f2ac49e1.gif" width=320 />