### PR TITLE
内部ストレージにあるアプリ固有のファイルを別アプリに共有する方法(FileProvider利用)

### DIFF
--- a/FileProvider/app/build.gradle
+++ b/FileProvider/app/build.gradle
@@ -19,13 +19,13 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.example.graygallery"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/FileProvider/app/src/main/AndroidManifest.xml
+++ b/FileProvider/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <!-- FileProvider を指定する. -->
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="com.example.graygallery.fileprovider"

--- a/FileProvider/app/src/main/java/com/example/graygallery/ui/AppViewModel.kt
+++ b/FileProvider/app/src/main/java/com/example/graygallery/ui/AppViewModel.kt
@@ -151,7 +151,7 @@ private fun getImagesFolder(context: Context): File {
             ?: error("You have to specify the sharable directory in res/xml/filepaths.xml")
 
     return File(context.filesDir, folderPath).also {
-        if (!it.exists()) { // ディリクトリが存在しなければ、ディレクトリ作成する.
+        if (!it.exists()) {
             it.mkdir()
         }
     }

--- a/FileProvider/app/src/main/java/com/example/graygallery/ui/DashboardFragment.kt
+++ b/FileProvider/app/src/main/java/com/example/graygallery/ui/DashboardFragment.kt
@@ -25,9 +25,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContract
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.TakePicturePreview
-import androidx.annotation.CallSuper
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
@@ -37,8 +35,8 @@ import com.google.android.material.snackbar.Snackbar
 class DashboardFragment : Fragment() {
     private val viewModel by viewModels<AppViewModel>()
     private lateinit var binding: FragmentDashboardBinding
-
     private val takePicture = registerForActivityResult(TakePicturePreview()) { bitmap ->
+        // 写真撮影後、画像データがbitmapに入る。キャンセル時はnullが渡ってくる。
         viewModel.saveImageFromCamera(bitmap)
     }
 
@@ -58,6 +56,7 @@ class DashboardFragment : Fragment() {
         binding = FragmentDashboardBinding.inflate(inflater, container, false)
 
         binding.takePicture.setOnClickListener {
+            // TakePicturePreviewは、 引数がVoidなので、nullを渡すでOK.
             takePicture.launch(null)
         }
 
@@ -81,7 +80,10 @@ class DashboardFragment : Fragment() {
     }
 }
 
+// 引数の型: Array<String>
+// 戻り値の型: Uri?
 class GetContentWithMimeTypes : ActivityResultContract<Array<String>, Uri?>() {
+    // {@link Activity#startActivityForResult} で使うインテントの作成.
     override fun createIntent(
         context: Context,
         input: Array<String>
@@ -96,11 +98,13 @@ class GetContentWithMimeTypes : ActivityResultContract<Array<String>, Uri?>() {
     override fun getSynchronousResult(
         context: Context,
         input: Array<String>
-    ): SynchronousResult<Uri?>? {
+    ): ActivityResultContract.SynchronousResult<Uri?>? {
         return null
     }
 
+    // 戻り値の処理.
     override fun parseResult(resultCode: Int, intent: Intent?): Uri? {
+        // intent.dataに選択した画像のuriが渡ってくる.
         return if (intent == null || resultCode != Activity.RESULT_OK) null else intent.data
     }
 }

--- a/FileProvider/app/src/main/res/xml/filepaths.xml
+++ b/FileProvider/app/src/main/res/xml/filepaths.xml
@@ -14,7 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
+<!-- 共有可能なディレクトリを指定する. -->
 <paths>
     <files-path path="images/" name="grayimages" />
 </paths>


### PR DESCRIPTION
ContentProviderを継承した[FileProvider](https://developer.android.com/reference/androidx/core/content/FileProvider)を使用して、アプリ固有のファイルを別アプリに共有することができます。

# 動作確認

OS9, 10, 11 ともに同じ挙動・

| Pixel 4 OS9 | Pixel 4 OS10 | Pixel 4 OS11 |
|:---|:---:|:---:|
| <img src="https://user-images.githubusercontent.com/16476224/116417800-90919780-a876-11eb-9145-9d573324d3ab.gif" height=400 width=200/> |<img src="https://user-images.githubusercontent.com/16476224/116416749-90dd6300-a875-11eb-88a6-871ff9c33c0b.gif" width=320 /> | <img src="https://user-images.githubusercontent.com/16476224/116418535-33e2ac80-a877-11eb-8131-48a9c91c441d.gif" width=320 /> |