### PR TITLE
OS10: mediaStoreを使った写真の位置情報の取得

### DIFF
--- a/MediaStore/app/build.gradle
+++ b/MediaStore/app/build.gradle
@@ -32,7 +32,7 @@ android {
     }
     defaultConfig {
         applicationId "com.android.samples.mediastore"
-        minSdkVersion 16
+        minSdkVersion 24
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
@@ -60,4 +60,6 @@ dependencies {
 
     androidTestImplementation "androidx.test:runner:$test_runner_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
+
+    implementation "androidx.exifinterface:exifinterface:1.3.2"
 }

--- a/MediaStore/app/src/main/AndroidManifest.xml
+++ b/MediaStore/app/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
 
+    <!-- Android 10から写真の位置情報の取得に必要なパーミッション. -->
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivity.kt
+++ b/MediaStore/app/src/main/java/com/android/samples/mediastore/MainActivity.kt
@@ -218,7 +218,8 @@ class MainActivity : AppCompatActivity() {
     private fun requestPermissionApi29() {
         if (!haveStoragePermission()) {
             val permissions = arrayOf(
-                Manifest.permission.READ_EXTERNAL_STORAGE
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.ACCESS_MEDIA_LOCATION // 写真の位置情報の取得に必要
             )
             ActivityCompat.requestPermissions(this, permissions, READ_EXTERNAL_STORAGE_REQUEST)
         }

--- a/MediaStore/app/src/main/java/com/android/samples/mediastore/MediaStoreImage.kt
+++ b/MediaStore/app/src/main/java/com/android/samples/mediastore/MediaStoreImage.kt
@@ -27,7 +27,9 @@ data class MediaStoreImage(
     val id: Long,
     val displayName: String,
     val dateAdded: Date,
-    val contentUri: Uri
+    val contentUri: Uri,
+    val lat: Float,
+    val long: Float
 ) {
     companion object {
         val DiffCallback = object : DiffUtil.ItemCallback<MediaStoreImage>() {


### PR DESCRIPTION
https://developer.android.com/training/data-storage/shared/media#location-info-photos

他アプリが作成したイメージファイルの位置情報を読み取るには、[ACCESS_MEDIA_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_MEDIA_LOCATION)権限が必要
re: https://youtu.be/UnJ3amzJM94?t=813

# 動作確認

OS 9, 10, 11 で位置情報を取得できることを確認